### PR TITLE
feat(subscriptions): add ability to test subscriptions

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,19 +1,40 @@
 import { Notification } from 'rxjs/Notification';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
+import { SubscriptionLog } from 'rxjs/testing/SubscriptionLog';
 import { TestMessage } from 'rxjs/testing/TestMessage';
 import { TestScheduler } from 'rxjs/testing/TestScheduler';
 
-import { getTestScheduler, initTestScheduler, resetTestScheduler } from './src/scheduler';
-import { TestColdObservable, TestHotObservable, TestObservable } from './src/test-observables';
+import {
+  getTestScheduler,
+  initTestScheduler,
+  resetTestScheduler,
+} from './src/scheduler';
+import {
+  TestColdObservable,
+  TestHotObservable,
+  TestObservable,
+} from './src/test-observables';
 
-export { getTestScheduler, initTestScheduler, resetTestScheduler } from './src/scheduler';
+export {
+  getTestScheduler,
+  initTestScheduler,
+  resetTestScheduler,
+} from './src/scheduler';
 
-export function hot(marbles: string, values?: any, error?: any): TestHotObservable {
+export function hot(
+  marbles: string,
+  values?: any,
+  error?: any,
+): TestHotObservable {
   return new TestHotObservable(marbles, values, error);
 }
 
-export function cold(marbles: string, values?: any, error?: any): TestColdObservable {
+export function cold(
+  marbles: string,
+  values?: any,
+  error?: any,
+): TestColdObservable {
   return new TestColdObservable(marbles, values, error);
 }
 
@@ -25,6 +46,7 @@ declare global {
   namespace jasmine {
     interface Matchers<T> {
       toBeObservable: any;
+      toHaveSubscriptions: any;
     }
   }
 }
@@ -66,8 +88,21 @@ function materializeInnerObservable(
 
 export function addMatchers() {
   jasmine.addMatchers({
+    toHaveSubscriptions: () => ({
+      compare: function(actual: TestObservable, marbles: string | string[]) {
+        const marblesArray: string[] =
+          typeof marbles === 'string' ? [marbles] : marbles;
+        const results: SubscriptionLog[] = marblesArray.map(marbles =>
+          TestScheduler.parseMarblesAsSubscriptions(marbles),
+        );
+
+        expect(results).toEqual(actual.getSubscriptions());
+
+        return { pass: true };
+      },
+    }),
     toBeObservable: () => ({
-      compare: function (actual: TestObservable, fixture: TestObservable) {
+      compare: function(actual: TestObservable, fixture: TestObservable) {
         const results: TestMessage[] = [];
         let subscription: Subscription;
         const scheduler = getTestScheduler();

--- a/spec/integration.spec.ts
+++ b/spec/integration.spec.ts
@@ -1,3 +1,4 @@
+import 'rxjs/add/operator/concat';
 import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/mapTo';
 
@@ -29,6 +30,27 @@ describe('Integration', () => {
     const expected = hot('--a--b', { a: 1, b: 2 });
 
     expect(expected.do(v => provided.next(v))).toBeObservable(expected);
+  });
+
+  it('should support testing subscriptions on hot observable', () => {
+    const source = hot('-a-^b---c-|');
+    const expected = cold('-b---c-|');
+    const subscription = '^------!';
+
+    expect(source).toBeObservable(expected);
+    expect(source).toHaveSubscriptions(subscription);
+  });
+
+  it('should identify subscription points', () => {
+    const obs1 = cold('-a---b-|');
+    const obs2 = cold('-c---d-|');
+    const expected = cold('-a---b--c---d-|');
+    const sub1 = '^------!';
+    const sub2 = '-------^------!';
+
+    expect(obs1.concat(obs2)).toBeObservable(expected);
+    expect(obs1).toHaveSubscriptions(sub1);
+    expect(obs2).toHaveSubscriptions(sub2);
   });
 
   it('should work with the test scheduler', () => {

--- a/src/test-observables.ts
+++ b/src/test-observables.ts
@@ -1,4 +1,5 @@
 import { Observable } from 'rxjs/Observable';
+import { SubscriptionLog } from 'rxjs/testing/SubscriptionLog';
 
 import { getTestScheduler } from './scheduler';
 
@@ -16,6 +17,10 @@ export class TestColdObservable extends Observable<any> {
       error,
     );
   }
+
+  getSubscriptions(): SubscriptionLog[] {
+    return this.source['subscriptions'];
+  }
 }
 
 export class TestHotObservable extends Observable<any> {
@@ -31,6 +36,10 @@ export class TestHotObservable extends Observable<any> {
       values,
       error,
     );
+  }
+
+  getSubscriptions(): SubscriptionLog[] {
+    return this.source['subscriptions'];
   }
 }
 


### PR DESCRIPTION
Hi!

## Description
This adds the `toHaveSubscriptions` assertion to jasmine-marbles to be
able to test subscriptions of _cold_ and _hot_ observables.

Have a great day!