### PR TITLE
refact(matcher): only import isEqual from lodash

### DIFF
--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -202,7 +202,7 @@
  limitations under the License.
  */
 
-import * as _ from 'lodash';
+import { isEqual } from 'lodash';
 
 function stringify(x: any): string {
   return JSON.stringify(x, function(key, value) {
@@ -240,7 +240,7 @@ export function observableMatcher(actual: any, expected: any) {
   if (Array.isArray(actual) && Array.isArray(expected)) {
     actual = actual.map(deleteErrorNotificationStack);
     expected = expected.map(deleteErrorNotificationStack);
-    const passed: any = _.isEqual(actual, expected);
+    const passed: any = isEqual(actual, expected);
     if (passed) {
       return;
     }


### PR DESCRIPTION
Hi!

This only imports the `isEqual` function from _lodash_ using ES6 import.

Related to #22

Thank you!