### PR TITLE
feat: export environment setup function for jasmine and remove module check

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -158,7 +158,7 @@ export function addMatchers() {
   });
 }
 
-if (typeof module === 'object' && module.exports) {
+export function setupEnvironment() {
   jasmine.getEnv().beforeAll(() => addMatchers());
 
   jasmine.getEnv().beforeEach(() => initTestScheduler());
@@ -167,3 +167,5 @@ if (typeof module === 'object' && module.exports) {
     resetTestScheduler();
   });
 }
+
+setupEnvironment();


### PR DESCRIPTION
This check is no longer needed and prevents the setup logic from running when tests are compiled to es2015. Also exports a `setupEnvironment` function to allow developers to run the initial setup manually.

Closes #21, #37, #40