### PR TITLE
Better error reporting

### DIFF
--- a/spec/integration.spec.ts
+++ b/spec/integration.spec.ts
@@ -103,4 +103,12 @@ describe('Integration', () => {
       expectObservable(provided).toBe('------(a|)', { a: val });
     });
   });
+
+  it('should support "not.toBeObservable"', () => {
+    const provided = of(1);
+
+    const expected = cold('(b|)', { b: 2 });
+
+    expect(provided).not.toBeObservable(expected);
+  });
 });

--- a/spec/map-symbols-to-notifications.spec.ts
+++ b/spec/map-symbols-to-notifications.spec.ts
@@ -1,0 +1,53 @@
+import { TestScheduler } from 'rxjs/testing';
+import { mapSymbolsToNotifications } from '../src/map-symbols-to-notifications';
+
+describe('Map symbols to frames', () => {
+  it('should map single symbol', () => {
+    const result = encodeSymbols('a', { a: 1 });
+    expect(result.a.value).toEqual(1);
+  });
+
+  it('should map multiple symbols', () => {
+    const result = encodeSymbols('---a--bc-d|', { a: 1, b: 2, c: 3, d: 4 });
+    expect(result.a.value).toEqual(1);
+    expect(result.b.value).toEqual(2);
+    expect(result.c.value).toEqual(3);
+    expect(result.d.value).toEqual(4);
+  });
+
+  it('should support groups', () => {
+    const result = encodeSymbols('---(abc)--(aa)-|', {
+      a: 1,
+      b: 2,
+      c: 3,
+      d: 4,
+    });
+    expect(result.a.value).toEqual(1);
+    expect(result.b.value).toEqual(2);
+    expect(result.c.value).toEqual(3);
+  });
+
+  it('should support subscription point', () => {
+    const result = encodeSymbols('---a-^-b-|', { a: 1, b: 2 });
+    expect(result.a.value).toEqual(1);
+    expect(result.b.value).toEqual(2);
+  });
+
+  it('should support time progression', () => {
+    const result = encodeSymbols('-- 100ms -a-^-b-|', { a: 1, b: 2 });
+    expect(result.a.value).toEqual(1);
+    expect(result.b.value).toEqual(2);
+  });
+
+  function encodeSymbols(marbles: string, values: { [key: string]: any }) {
+    const expected = TestScheduler.parseMarbles(
+      marbles,
+      values,
+      undefined,
+      true,
+      true,
+    );
+
+    return mapSymbolsToNotifications(marbles, expected);
+  }
+});

--- a/spec/marble-unparser.spec.ts
+++ b/spec/marble-unparser.spec.ts
@@ -1,0 +1,46 @@
+import { TestScheduler } from 'rxjs/testing';
+import { unparseMarble } from '../src/marble-unparser';
+
+describe('Marble unparser', () => {
+  describe('Basic unparsing with single frame symbol', () => {
+    it('should unparse single frame', () => {
+      expectToUnparse('a', 'a');
+    });
+
+    it('should respect empty frames', () => {
+      expectToUnparse('---a-aaa--a', '---a-aaa--a');
+    });
+
+    it('should trim empty suffix frames', () => {
+      expectToUnparse('---a-aaa--a----', '---a-aaa--a');
+    });
+
+    it('should support errors', () => {
+      expectToUnparse('--a-#', '--a-#');
+    });
+
+    it('should support stream completion', () => {
+      expectToUnparse('--a-|', '--a-|');
+    });
+
+    it('should support time progression', () => {
+      expectToUnparse('- 20ms -a', '----a');
+    });
+
+    it('should support groups', () => {
+      expectToUnparse('-(aa)--a', '-(aa)--a');
+    });
+
+    function expectToUnparse(sourceMarble: string, expectedMarble: string) {
+      const testMessage = TestScheduler.parseMarbles(
+        sourceMarble,
+        { a: 1 },
+        undefined,
+        true,
+        true,
+      );
+
+      expect(unparseMarble(testMessage, n => 'a')).toBe(expectedMarble);
+    }
+  });
+});

--- a/src/map-symbols-to-notifications.ts
+++ b/src/map-symbols-to-notifications.ts
@@ -1,0 +1,43 @@
+import { TestMessage } from 'rxjs/internal/testing/TestMessage';
+import { Notification } from 'rxjs';
+
+export function mapSymbolsToNotifications(
+  marbles: string,
+  messagesArg: TestMessage[],
+): { [key: string]: Notification<any> } {
+  const messages = messagesArg.slice();
+  const result: { [key: string]: Notification<any> } = {};
+
+  for (let i = 0; i < marbles.length; i++) {
+    const symbol = marbles[i];
+
+    switch (symbol) {
+      case ' ':
+      case '-':
+      case '^':
+      case '(':
+      case ')':
+        break;
+      case '#':
+      case '|': {
+        messages.shift();
+        break;
+      }
+      default: {
+        if ((symbol.match(/^[0-9]$/) && i === 0) || marbles[i - 1] === ' ') {
+          const buffer = marbles.slice(i);
+          const match = buffer.match(/^([0-9]+(?:\.[0-9]+)?)(ms|s|m) /);
+          if (match) {
+            i += match[0].length - 1;
+          }
+          break;
+        }
+
+        const message = messages.shift()!;
+        result[symbol] = message.notification;
+      }
+    }
+  }
+
+  return result;
+}

--- a/src/marble-unparser.ts
+++ b/src/marble-unparser.ts
@@ -1,0 +1,62 @@
+import { TestMessage } from 'rxjs/internal/testing/TestMessage';
+import { Notification } from 'rxjs';
+
+export function unparseMarble(
+  result: TestMessage[],
+  assignSymbolFn: (a: Notification<any>) => string,
+): string {
+  const FRAME_TIME_FACTOR = 10; // need to be up to date with `TestScheduler.frameTimeFactor`
+  let frames = 0;
+  let marble = '';
+  let isInGroup = false;
+  let groupMembersAmount = 0;
+  let index = 0;
+
+  const isNextMessageInTheSameFrame = () => {
+    const nextMessage = result[index + 1];
+    return nextMessage && nextMessage.frame === result[index].frame;
+  };
+
+  result.forEach((testMessage, i) => {
+    index = i;
+
+    const framesDiff = testMessage.frame - frames;
+    const emptyFramesAmount =
+      framesDiff > 0 ? framesDiff / FRAME_TIME_FACTOR : 0;
+    marble += '-'.repeat(emptyFramesAmount);
+
+    if (isNextMessageInTheSameFrame()) {
+      if (!isInGroup) {
+        marble += '(';
+      }
+      isInGroup = true;
+    }
+
+    switch (testMessage.notification.kind) {
+      case 'N':
+        marble += assignSymbolFn(testMessage.notification);
+        break;
+      case 'E':
+        marble += '#';
+        break;
+      case 'C':
+        marble += '|';
+        break;
+    }
+
+    if (isInGroup) {
+      groupMembersAmount += 1;
+    }
+
+    if (!isNextMessageInTheSameFrame() && isInGroup) {
+      marble += ')';
+      isInGroup = false;
+      frames += (groupMembersAmount + 1) * FRAME_TIME_FACTOR;
+      groupMembersAmount = 0;
+    } else {
+      frames = testMessage.frame + FRAME_TIME_FACTOR;
+    }
+  });
+
+  return marble;
+}


### PR DESCRIPTION
Hi,
this PR introduces more readable error reporting. It will display message in marble format, like in the screenshot:

```js
  it('should work with a cold observable', () => {
    const provided = cold('-a----b|', { a: 1, b: 2 });
    const expected = cold('--a---b|', { a: 1, b: 3 });

    expect(provided).toBeObservable(expected);
  });
```
![jasmine-marbles-test-report](https://user-images.githubusercontent.com/6236664/82121988-21b84d00-9791-11ea-9da8-8019a8e3d2c3.png)

- it prints marble comparison and detailed `JSON.stringified` test messages below
- if notification is found in the expected `TestObservable`, then it will match marble character to this Notification, if not, the character will be equal to `?`

Additionally, it fixes `not.toBeObservable`.

Fixes #51, #11 

Please let me know what do you think about these changes :)