### PR TITLE
Fix: 'Spec '...' has no expectations.' warning

### DIFF
--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -242,6 +242,7 @@ export function observableMatcher(actual: any, expected: any) {
     expected = expected.map(deleteErrorNotificationStack);
     const passed: any = isEqual(actual, expected);
     if (passed) {
+      expect(passed).toBe(true);
       return;
     }
 


### PR DESCRIPTION
Fixes https://github.com/synapse-wireless-labs/jasmine-marbles/issues/59

If the only expectation in a testcase is `expectObservable(actual$).toBe('a', { a: 0 });` then currently the 'Spec '...' has no expectations.' warning is shown.

When actual is an array and passed is true currently no expectations are called. The expectations are currently only called if actual and expected values are not equal.

Fixed by adding an expectation for when actual is an array and passed is true.