### PR TITLE
refactor: remove usage of internal RxJS testing APIs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,4 @@
 import { Notification, Observable, Subscription } from 'rxjs';
-import { SubscriptionLog } from 'rxjs/internal/testing/SubscriptionLog';
-import { TestMessage } from 'rxjs/internal/testing/TestMessage';
 import { TestScheduler } from 'rxjs/testing';
 
 import {
@@ -15,6 +13,7 @@ import {
 } from './src/test-observables';
 import { unparseMarble } from './src/marble-unparser';
 import { mapSymbolsToNotifications } from './src/map-symbols-to-notifications';
+import { TestMessages } from './src/types';
 
 export {
   getTestScheduler,
@@ -65,8 +64,8 @@ declare global {
 function materializeInnerObservable(
   observable: Observable<any>,
   outerFrame: number,
-): TestMessage[] {
-  const messages: TestMessage[] = [];
+): TestMessages {
+  const messages: TestMessages = [];
   const scheduler = getTestScheduler();
 
   observable.subscribe(
@@ -98,7 +97,7 @@ export function addMatchers() {
       compare: function(actual: TestObservable, marbles: string | string[]) {
         const marblesArray: string[] =
           typeof marbles === 'string' ? [marbles] : marbles;
-        const results: SubscriptionLog[] = marblesArray.map(marbles =>
+        const results = marblesArray.map(marbles =>
           TestScheduler.parseMarblesAsSubscriptions(marbles),
         );
 
@@ -109,7 +108,7 @@ export function addMatchers() {
     }),
     toBeObservable: (utils, equalityTester) => ({
       compare: function(actual: TestObservable, fixture: TestObservable) {
-        const results: TestMessage[] = [];
+        const results: TestMessages = [];
         let subscription: Subscription;
         const scheduler = getTestScheduler();
 
@@ -177,7 +176,7 @@ export function addMatchers() {
 
 function buildNotificationToSymbolMapper(
   expectedMarbles: string,
-  expectedMessages: TestMessage[],
+  expectedMessages: TestMessages,
   equalityFn: (a: any, b: any) => boolean,
 ) {
   const symbolsToNotificationsMap = mapSymbolsToNotifications(
@@ -195,9 +194,9 @@ function buildNotificationToSymbolMapper(
 
 function formatMessage(
   expectedMarbles: string,
-  expectedMessages: TestMessage[],
+  expectedMessages: TestMessages,
   receivedMarbles: string,
-  receivedMessages: TestMessage[],
+  receivedMessages: TestMessages,
 ) {
   return `
     Expected: ${expectedMarbles},

--- a/package.json
+++ b/package.json
@@ -59,14 +59,14 @@
     "prettier": "^1.5.2",
     "rimraf": "^2.6.1",
     "rollup": "^0.41.4",
-    "rxjs": "^6.4.0",
+    "rxjs": "^6.5.3",
     "ts-node": "^3.1.0",
-    "typescript": "^2.4.1"
+    "typescript": "^4.1.0"
   },
   "peerDependencies": {
-    "rxjs": "^6.4.0"
+    "rxjs": "^6.5.3"
   },
   "dependencies": {
-    "lodash": "^4.17.12"
+    "lodash": "^4.17.20"
   }
 }

--- a/src/map-symbols-to-notifications.ts
+++ b/src/map-symbols-to-notifications.ts
@@ -1,9 +1,10 @@
-import { TestMessage } from 'rxjs/internal/testing/TestMessage';
 import { Notification } from 'rxjs';
+
+import { TestMessages } from './types';
 
 export function mapSymbolsToNotifications(
   marbles: string,
-  messagesArg: TestMessage[],
+  messagesArg: TestMessages,
 ): { [key: string]: Notification<any> } {
   const messages = messagesArg.slice();
   const result: { [key: string]: Notification<any> } = {};

--- a/src/marble-unparser.ts
+++ b/src/marble-unparser.ts
@@ -1,8 +1,9 @@
-import { TestMessage } from 'rxjs/internal/testing/TestMessage';
 import { Notification } from 'rxjs';
 
+import { TestMessages } from './types';
+
 export function unparseMarble(
-  result: TestMessage[],
+  result: TestMessages,
   assignSymbolFn: (a: Notification<any>) => string,
 ): string {
   const FRAME_TIME_FACTOR = 10; // need to be up to date with `TestScheduler.frameTimeFactor`

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -6,6 +6,7 @@ let scheduler: TestScheduler | null;
 
 export function initTestScheduler(): void {
   scheduler = new TestScheduler(observableMatcher);
+  scheduler['runMode'] = true;
 }
 
 export function getTestScheduler(): TestScheduler {

--- a/src/test-observables.ts
+++ b/src/test-observables.ts
@@ -1,34 +1,23 @@
 import { Observable } from 'rxjs';
-import { SubscriptionLog } from 'rxjs/internal/testing/SubscriptionLog';
 
 import { getTestScheduler } from './scheduler';
-import { TestScheduler } from 'rxjs/testing';
-import { HotObservable } from 'rxjs/internal/testing/HotObservable';
-import { ColdObservable } from 'rxjs/internal/testing/ColdObservable';
+import { SubscriptionLogs } from './types';
 
 export class TestColdObservable extends Observable<any> {
   constructor(
     public marbles: string,
-    public values?: any[],
+    public values?: { [name: string]: any },
     public error?: any,
   ) {
     super();
 
     const scheduler = getTestScheduler();
+    const cold = scheduler.createColdObservable(marbles, values, error);
 
-    const messages = TestScheduler.parseMarbles(
-      marbles,
-      values,
-      error,
-      undefined,
-      true,
-    );
-    const cold = new ColdObservable<any>(messages, scheduler);
     this.source = cold;
-    scheduler.coldObservables.push(cold);
   }
 
-  getSubscriptions(): SubscriptionLog[] {
+  getSubscriptions(): SubscriptionLogs[] {
     return (this.source as any)['subscriptions'];
   }
 }
@@ -36,26 +25,18 @@ export class TestColdObservable extends Observable<any> {
 export class TestHotObservable extends Observable<any> {
   constructor(
     public marbles: string,
-    public values?: any[],
+    public values?: { [name: string]: any },
     public error?: any,
   ) {
     super();
 
     const scheduler = getTestScheduler();
+    const hot = scheduler.createHotObservable(marbles, values, error);
 
-    const messages = TestScheduler.parseMarbles(
-      marbles,
-      values,
-      error,
-      undefined,
-      true,
-    );
-    const hot = new HotObservable<any>(messages, scheduler);
     this.source = hot;
-    scheduler.hotObservables.push(hot);
   }
 
-  getSubscriptions(): SubscriptionLog[] {
+  getSubscriptions(): SubscriptionLogs[] {
     return (this.source as any)['subscriptions'];
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,13 @@
+import { TestScheduler } from 'rxjs/testing';
+
+/**
+ * Exported return type of TestMessage[] to avoid importing internal APIs.
+ */
+export type TestMessages = ReturnType<typeof TestScheduler.parseMarbles>;
+
+/**
+ * Exported return type of SubscriptionLog to avoid importing internal APIs.
+ */
+export type SubscriptionLogs = ReturnType<
+  typeof TestScheduler.parseMarblesAsSubscriptions
+>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1047,10 +1047,15 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
-lodash@^4.14.14, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.2.1:
+lodash@^4.14.14, lodash@^4.17.13, lodash@^4.2.1:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^4.17.20:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -1565,10 +1570,10 @@ rollup@^0.41.4:
   dependencies:
     source-map-support "^0.4.0"
 
-rxjs@^6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.4.0.tgz#f3bb0fe7bda7fb69deac0c16f17b50b0b8790504"
-  integrity sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==
+rxjs@^6.5.3:
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
+  integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
   dependencies:
     tslib "^1.9.0"
 
@@ -1833,9 +1838,10 @@ tslib@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
 
-typescript@^2.4.1:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"
+typescript@^4.1.0:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
+  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
 
 uglify-js@^3.1.4:
   version "3.6.2"


### PR DESCRIPTION
Refactors internals to remove all usage of private RxJS testing APIs, removing possibility of different RxJS symbols being imported.

Closes #39, #44