### PR TITLE
fix: use lodash for internal isEqual check

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 import { Notification, Observable, Subscription } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
+import { isEqual } from 'lodash';
 
 import {
   getTestScheduler,
@@ -151,14 +152,14 @@ export function addMatchers() {
           true,
         );
 
-        if (utils.equals(results, expected)) {
+        if (isEqual(results, expected)) {
           return { pass: true };
         }
 
         const mapNotificationToSymbol = buildNotificationToSymbolMapper(
           fixture.marbles,
           expected,
-          utils.equals,
+          isEqual,
         );
         const receivedMarble = unparseMarble(results, mapNotificationToSymbol);
 


### PR DESCRIPTION
Fixes a bug when running in a Jest environment