### PR TITLE
chore(deps): update jasmine to ^3.7.0

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -243,10 +243,10 @@ function formatMessage(
 }
 
 export function setupEnvironment() {
-  jasmine.getEnv().beforeAll(() => addMatchers());
+  beforeAll(() => addMatchers());
 
-  jasmine.getEnv().beforeEach(() => initTestScheduler());
-  jasmine.getEnv().afterEach(() => {
+  beforeEach(() => initTestScheduler());
+  afterEach(() => {
     getTestScheduler().flush();
     resetTestScheduler();
   });

--- a/package.json
+++ b/package.json
@@ -46,15 +46,14 @@
     ]
   },
   "devDependencies": {
-    "@types/jasmine": "^2.8.0",
+    "@types/jasmine": "^3.7.4",
     "@types/lodash": "^4.14.106",
     "@types/node": "^8.0.14",
     "conventional-changelog": "^3.1.12",
     "conventional-changelog-cli": "^2.0.25",
     "cpy-cli": "^1.0.1",
     "husky": "^0.14.3",
-    "jasmine": "^2.8.0",
-    "jasmine-core": "^2.8.0",
+    "jasmine": "^3.7.0",
     "nyc": "^14",
     "prettier": "^1.5.2",
     "rimraf": "^2.6.1",

--- a/spec/map-symbols-to-notifications.spec.ts
+++ b/spec/map-symbols-to-notifications.spec.ts
@@ -1,18 +1,34 @@
+import { NextNotification, ObservableNotification } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { mapSymbolsToNotifications } from '../src/map-symbols-to-notifications';
+
+function encodeSymbols(
+  marbles: string,
+  values: { [key: string]: any },
+): { [key: string]: ObservableNotification<any> } {
+  const expected = TestScheduler.parseMarbles(
+    marbles,
+    values,
+    undefined,
+    true,
+    true,
+  );
+
+  return mapSymbolsToNotifications(marbles, expected);
+}
 
 describe('Map symbols to frames', () => {
   it('should map single symbol', () => {
     const result = encodeSymbols('a', { a: 1 });
-    expect(result.a.value).toEqual(1);
+    expect((result.a as NextNotification<any>).value).toEqual(1);
   });
 
   it('should map multiple symbols', () => {
     const result = encodeSymbols('---a--bc-d|', { a: 1, b: 2, c: 3, d: 4 });
-    expect(result.a.value).toEqual(1);
-    expect(result.b.value).toEqual(2);
-    expect(result.c.value).toEqual(3);
-    expect(result.d.value).toEqual(4);
+    expect((result.a as NextNotification<any>).value).toEqual(1);
+    expect((result.b as NextNotification<any>).value).toEqual(2);
+    expect((result.c as NextNotification<any>).value).toEqual(3);
+    expect((result.d as NextNotification<any>).value).toEqual(4);
   });
 
   it('should support groups', () => {
@@ -22,32 +38,20 @@ describe('Map symbols to frames', () => {
       c: 3,
       d: 4,
     });
-    expect(result.a.value).toEqual(1);
-    expect(result.b.value).toEqual(2);
-    expect(result.c.value).toEqual(3);
+    expect((result.a as NextNotification<any>).value).toEqual(1);
+    expect((result.b as NextNotification<any>).value).toEqual(2);
+    expect((result.c as NextNotification<any>).value).toEqual(3);
   });
 
   it('should support subscription point', () => {
     const result = encodeSymbols('---a-^-b-|', { a: 1, b: 2 });
-    expect(result.a.value).toEqual(1);
-    expect(result.b.value).toEqual(2);
+    expect((result.a as NextNotification<any>).value).toEqual(1);
+    expect((result.b as NextNotification<any>).value).toEqual(2);
   });
 
   it('should support time progression', () => {
     const result = encodeSymbols('-- 100ms -a-^-b-|', { a: 1, b: 2 });
-    expect(result.a.value).toEqual(1);
-    expect(result.b.value).toEqual(2);
+    expect((result.a as NextNotification<any>).value).toEqual(1);
+    expect((result.b as NextNotification<any>).value).toEqual(2);
   });
-
-  function encodeSymbols(marbles: string, values: { [key: string]: any }) {
-    const expected = TestScheduler.parseMarbles(
-      marbles,
-      values,
-      undefined,
-      true,
-      true,
-    );
-
-    return mapSymbolsToNotifications(marbles, expected);
-  }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -89,9 +89,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@types/jasmine@^2.8.0":
-  version "2.8.7"
-  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.8.7.tgz#3fe583928ae0a22cdd34cedf930eeffeda2602fd"
+"@types/jasmine@^3.7.4":
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-3.7.4.tgz#99a49aa9a5f8dc86fc249ed13ed59552c6ce862d"
+  integrity sha512-L3FKeEwMm8e8hqGvt7cSesVmGtavpRyHV1FNDq+Pm5pS4x5eFmE70ZERXCSBWAiLQqXBcZRUrwV59FZLQl/GxQ==
 
 "@types/lodash@^4.14.106":
   version "4.14.108"
@@ -605,10 +606,6 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
-exit@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
-
 find-cache-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
@@ -715,7 +712,7 @@ glob@^6.0.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.5, glob@^7.0.6:
+glob@^7.0.5:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -730,6 +727,18 @@ glob@^7.1.3:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.6:
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -951,17 +960,18 @@ istanbul-reports@^2.2.4:
   dependencies:
     handlebars "^4.1.2"
 
-jasmine-core@^2.8.0, jasmine-core@~2.99.0:
-  version "2.99.1"
-  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.99.1.tgz#e6400df1e6b56e130b61c4bcd093daa7f6e8ca15"
+jasmine-core@~3.7.0:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.7.1.tgz#0401327f6249eac993d47bbfa18d4e8efacfb561"
+  integrity sha512-DH3oYDS/AUvvr22+xUBW62m1Xoy7tUlY1tsxKEJvl5JeJ7q8zd1K5bUwiOxdH+erj6l2vAMM3hV25Xs9/WrmuQ==
 
-jasmine@^2.8.0:
-  version "2.99.0"
-  resolved "https://registry.yarnpkg.com/jasmine/-/jasmine-2.99.0.tgz#8ca72d102e639b867c6489856e0e18a9c7aa42b7"
+jasmine@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/jasmine/-/jasmine-3.7.0.tgz#d36638c0c815e6ad5666676e386d79e2ccb70835"
+  integrity sha512-wlzGQ+cIFzMEsI+wDqmOwvnjTvolLFwlcpYLCqSPPH0prOQaW3P+IzMhHYn934l1imNvw07oCyX+vGUv3wmtSQ==
   dependencies:
-    exit "^0.1.2"
-    glob "^7.0.6"
-    jasmine-core "~2.99.0"
+    glob "^7.1.6"
+    jasmine-core "~3.7.0"
 
 js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Updated jasmine dev dep to ^3.7.0 , the @types/jasmines dep too.
Removed jasmine-core as it seems it is already part of jasmine.

Seems that jasmine beforeAll, beforeEach and afterEach are no longer accessible from jasmine.getEnv(), so i changed the setupEnvironment function

Some changes in spec/map-symbols-to-notifications.spec.ts as it seems it needs some casting from ObservableNotification to NextNotification, but i think it's related to my previous MR :(