### PR TITLE
chore(deps): update rollupjs to ^2.49.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "nyc": "^14",
     "prettier": "^1.5.2",
     "rimraf": "^2.6.1",
-    "rollup": "^0.41.4",
+    "rollup": "^2.49.0",
     "rxjs": "^7.0.0",
     "ts-node": "^9.1.1",
     "typescript": "^4.2.0"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,13 +1,15 @@
 export default {
-  entry: './release/es6/index.js',
-  dest: './release/bundles/jasmine-marbles.umd.js',
-  format: 'umd',
-  moduleName: 'jasmine-marbles',
-  globals: {
-    'rxjs': 'Rx',
-    'rxjs/testing': 'Rx',
-    'lodash': '_'
-  },
+  input: './release/es6/index.js',
+  output:  {
+    file:   './release/bundles/jasmine-marbles.umd.js',
+    name:  'jasmine-marbles',
+    format: 'umd',
+    globals: {
+      'rxjs': 'Rx',
+      'rxjs/testing': 'Rx',
+      'lodash': '_'
+    },
+  }, 
   external: [
     'rxjs',
     'rxjs/testing',

--- a/yarn.lock
+++ b/yarn.lock
@@ -650,6 +650,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
+fsevents@~2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
@@ -1591,11 +1596,12 @@ rimraf@^2.6.2, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rollup@^0.41.4:
-  version "0.41.6"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.41.6.tgz#e0d05497877a398c104d816d2733a718a7a94e2a"
-  dependencies:
-    source-map-support "^0.4.0"
+rollup@^2.49.0:
+  version "2.49.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.49.0.tgz#f0e5bb2b770ddf1be8cc30d4cce3457574c8c871"
+  integrity sha512-UnrCjMXICx9q0jF8L7OYs7LPk95dW0U5UYp/VANnWqfuhyr66FWi/YVlI34Oy8Tp4ZGLcaUDt4APJm80b9oPWQ==
+  optionalDependencies:
+    fsevents "~2.3.1"
 
 rxjs@^7.0.0:
   version "7.0.1"
@@ -1636,12 +1642,6 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
-source-map-support@^0.4.0:
-  version "0.4.16"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.16.tgz#16fecf98212467d017d586a2af68d628b9421cd8"
-  dependencies:
-    source-map "^0.5.6"
-
 source-map-support@^0.5.17:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
@@ -1654,10 +1654,6 @@ source-map@^0.5.0:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
-
-source-map@^0.5.6:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
 source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"


### PR DESCRIPTION
Updated rollup to ^2.49.0. It required to change the rollup.config.js file.
I didn't know much about rollupjs, but quickly tested the results in a project and it seems that it's still working :relieved: 

Please review/test to confirm it's ok