### PR TITLE
fix: update marble syntax link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Marble testing helpers for RxJS and Jasmine
 
 Helpful Links
 
-* [Marble Syntax](https://github.com/ReactiveX/rxjs/blob/master/docs_app/content/guide/testing/marble-testing.md#marble-syntax "ReactiveX Documentation")
+* [Marble Syntax](https://github.com/ReactiveX/rxjs/blob/master/apps/rxjs.dev/content/guide/testing/marble-testing.md#marble-syntax "ReactiveX Documentation")
 * [Providing Mock Actions for testing NgRx Actions with jasmine-marbles](https://ngrx.io/guide/effects/testing "NgRx Documentation")
 
 # Supported RxJS versions


### PR DESCRIPTION
hence folder re-structing in `rxjs` repo, so I would like to update the link path